### PR TITLE
feat: add hour & minute start/end

### DIFF
--- a/docs/components/content/Modify.vue
+++ b/docs/components/content/Modify.vue
@@ -151,6 +151,46 @@ const fns: Record<
     example: "date",
     tip: 'To produce a date in a given timezone either include the offset in the date string (ex: "2021-01-01T00:00:00-0800") or use the <code>tzDate</code> function.',
   },
+  minuteStart: {
+    description: `Returns a new Date object with the seconds part of the time set to 00.000 (local time).`,
+    return: "Date",
+    arguments: [
+      {
+        name: "date",
+        type: "string | Date",
+      },
+    ],
+  },
+  minuteEnd: {
+    description: `Returns a new Date object with the seconds part of the time set to 59.999 (local time).`,
+    return: "Date",
+    arguments: [
+      {
+        name: "date",
+        type: "string | Date",
+      },
+    ],
+  },
+  hourStart: {
+    description: `Returns a new Date object with the minutes part of the time set to 00:00.000 (local time).`,
+    return: "Date",
+    arguments: [
+      {
+        name: "date",
+        type: "string | Date",
+      },
+    ],
+  },
+  hourEnd: {
+    description: `Returns a new Date object with the minutes part of the time set to 59:59.999 (local time).`,
+    return: "Date",
+    arguments: [
+      {
+        name: "date",
+        type: "string | Date",
+      },
+    ],
+  },
   dayStart: {
     description: `Returns a new Date object with the time set to 00:00:00.000 (local time).`,
     return: "Date",
@@ -160,10 +200,10 @@ const fns: Record<
         type: "string | Date",
       },
     ],
-    example: "dayStart",
+
   },
   dayEnd: {
-    description: `Returns a new Date object with the time set to 23:59:59 (local).`,
+    description: `Returns a new Date object with the time set to 23:59:59.999 (local time).`,
     return: "Date",
     arguments: [
       {

--- a/src/__tests__/dayEnd.spec.ts
+++ b/src/__tests__/dayEnd.spec.ts
@@ -3,7 +3,7 @@ import { dayEnd } from "../dayEnd"
 process.env.TZ = "America/New_York"
 
 describe("dayEnd", () => {
-  it("can become the start of the day", () => {
+  it("can become the end of the day", () => {
     expect(dayEnd("2023-02-22T12:00:00Z").toISOString()).toBe(
       "2023-02-23T04:59:59.999Z"
     )

--- a/src/__tests__/hourEnd.spec.ts
+++ b/src/__tests__/hourEnd.spec.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from "vitest"
+import { hourEnd } from "../hourEnd"
+process.env.TZ = "America/New_York"
+
+describe("hourEnd", () => {
+  it("can become the end of the hour", () => {
+    expect(hourEnd("2023-02-22T12:30:00Z").toISOString()).toBe(
+      "2023-02-22T17:59:59.999Z"
+    )
+  })
+})

--- a/src/__tests__/hourStart.spec.ts
+++ b/src/__tests__/hourStart.spec.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from "vitest"
+import { hourStart } from "../hourStart"
+process.env.TZ = "America/New_York"
+
+describe("hourStart", () => {
+  it("can become the start of the hour", () => {
+    expect(hourStart("2023-02-22T12:30:00Z").toISOString()).toBe(
+      "2023-02-22T17:00:00.000Z"
+    )
+  })
+})

--- a/src/__tests__/minuteEnd.spec.ts
+++ b/src/__tests__/minuteEnd.spec.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from "vitest"
+import { minuteEnd } from "../minuteEnd"
+process.env.TZ = "America/New_York"
+
+describe("minuteEnd", () => {
+  it("can become the end of the hour", () => {
+    expect(minuteEnd("2023-02-22T12:30:30Z").toISOString()).toBe(
+      "2023-02-22T17:30:59.999Z"
+    )
+  })
+})

--- a/src/__tests__/minuteStart.spec.ts
+++ b/src/__tests__/minuteStart.spec.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from "vitest"
+import { minuteStart } from "../minuteStart"
+process.env.TZ = "America/New_York"
+
+describe("minuteStart", () => {
+  it("can become the start of the minute", () => {
+    expect(minuteStart("2023-02-22T12:30:30Z").toISOString()).toBe(
+      "2023-02-22T17:30:00.000Z"
+    )
+  })
+})

--- a/src/hourEnd.ts
+++ b/src/hourEnd.ts
@@ -1,0 +1,12 @@
+import { date } from "./date"
+import type { DateInput } from "./types"
+
+/**
+ * Returns a Date object for end of the given hour.
+ * @param inputDate - A string or Date object
+ */
+export function hourEnd(inputDate: DateInput): Date {
+  const d = date(inputDate)
+  d.setMinutes(59, 59, 999)
+  return d
+}

--- a/src/hourStart.ts
+++ b/src/hourStart.ts
@@ -1,0 +1,12 @@
+import { date } from "./date"
+import type { DateInput } from "./types"
+
+/**
+ * Returns a Date object for start of the given hour.
+ * @param inputDate - A string or Date object
+ */
+export function hourStart(inputDate: DateInput): Date {
+  const d = date(inputDate)
+  d.setMinutes(0, 0)
+  return d
+}

--- a/src/minuteEnd.ts
+++ b/src/minuteEnd.ts
@@ -1,0 +1,12 @@
+import { date } from "./date"
+import type { DateInput } from "./types"
+
+/**
+ * Returns a Date object for end of the given minute.
+ * @param inputDate - A string or Date object
+ */
+export function minuteEnd(inputDate: DateInput): Date {
+  const d = date(inputDate)
+  d.setSeconds(59, 999)
+  return d
+}

--- a/src/minuteStart.ts
+++ b/src/minuteStart.ts
@@ -1,0 +1,12 @@
+import { date } from "./date"
+import type { DateInput } from "./types"
+
+/**
+ * Returns a Date object for start of the given minute.
+ * @param inputDate - A string or Date object
+ */
+export function minuteStart(inputDate: DateInput): Date {
+  const d = date(inputDate)
+  d.setSeconds(0)
+  return d
+}


### PR DESCRIPTION
This PR introduces some new start and end functions for setting a date object to the end of an hour and minute.