### PR TITLE
fix: change `d` output to `console.log`

### DIFF
--- a/docs/examples/applyOffset.ts
+++ b/docs/examples/applyOffset.ts
@@ -1,9 +1,12 @@
-import { offset, applyOffset } from "@formkit/tempo"
+import { offset, applyOffset, date } from "@formkit/tempo"
 
 // 💡 Pickup at 9:30 in Europe/Lisbon
 
 // Notice that the time has no offset, thus it is "local":
 const d = "2025-03-25 09:30"
+
+// local time:
+console.log(new Date(d).toISOString())
 
 // Lisbon is at UTC+0:
 const lisbonOffset = offset(d, "Europe/Lisbon")


### PR DESCRIPTION
This RP fixes: #8 

Comment: https://github.com/formkit/tempo/issues/8#issuecomment-1961857023

<img width="776" alt="image" src="https://github.com/formkit/tempo/assets/82209198/bcd3d85c-c43b-4d20-83ba-6ed382c37edc">

Added `console.log` for better understanding ❤️ 