### PR TITLE
docs: added size-limit

### DIFF
--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -1,0 +1,19 @@
+const funcs = require("./dist/index.cjs")
+
+const path = "./dist/index.mjs"
+
+module.exports = [
+  ...Object.keys(funcs)
+    .map((name) => {
+      if (name === "format" || name === "parse") {
+        return
+      }
+      return { path, name, import: `{ ${name} }` }
+    })
+    .filter(Boolean),
+
+  { path, limit: "2.9 kb", import: "{ format }", name: "format" },
+  { path, limit: "4.3 kb", import: "{ parse }", name: "parse" },
+  { path, limit: "5.1 kb", import: "*", name: "all esm" },
+  { path: "./dist/index.cjs", limit: "5.4 kb", import: "*", name: "all cjs" },
+]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Tempo is a new library in a proud tradition of JavaScript date and time librarie
 
 Tempo is best thought of as a collection of utilities for working with `Date` objects — an important distinction from other libraries that provide custom date primitives. Under the hood, Tempo mines JavaScript's `Intl.DateTimeFormat` to extract complex data like timezones offsets and locale aware date formats giving you a simple API to format, parse, and manipulates dates.
 
+Tempo is tiny tree-shakable framework, you can only take what you need. All functionality is available in **5.1 kB for esm** and **5.4 kB for cjs** modules (minified and brotlied). [Size Limit](https://github.com/ai/size-limit) controls the size.
+
 <a href="https://tempo.formkit.com">
 <img src="docs/public/read-the-docs.png" alt="Read the docs" width="200" height="43">
 </a>

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "test": "TZ=\"America/New_York\" vitest",
     "docs-build": "cd ./docs && pnpm run build",
     "publint": "publint",
-    "release": "pnpm build && bumpp && pnpm publish"
+    "release": "pnpm build && bumpp && pnpm publish",
+    "size": "npm run build && size-limit"
   },
   "files": [
     "dist",
@@ -39,9 +40,11 @@
   "author": "Justin Schroeder <justin@formkit.com>",
   "license": "MIT",
   "devDependencies": {
+    "@size-limit/preset-small-lib": "^11.0.2",
     "@types/node": "^20.11.10",
     "bumpp": "^9.3.0",
     "publint": "^0.2.7",
+    "size-limit": "^11.0.2",
     "tsup": "^8.0.1",
     "typescript": "^5.3.3",
     "vitest": "^1.2.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@size-limit/preset-small-lib':
+        specifier: ^11.0.2
+        version: 11.0.2(size-limit@11.0.2)
       '@types/node':
         specifier: ^20.11.10
         version: 20.11.16
@@ -17,6 +20,9 @@ importers:
       publint:
         specifier: ^0.2.7
         version: 0.2.7
+      size-limit:
+        specifier: ^11.0.2
+        version: 11.0.2
       tsup:
         specifier: ^8.0.1
         version: 8.0.1(typescript@5.3.3)
@@ -62,7 +68,7 @@ importers:
         version: 10.7.2(nuxt@3.10.0)(vue@3.4.15)
       nuxt:
         specifier: ^3.10.0
-        version: 3.10.0(@types/node@18.19.14)(vite@5.0.12)
+        version: 3.10.0(@types/node@18.19.14)(typescript@5.3.3)(vite@5.0.12)
       nuxt-fathom:
         specifier: ^0.0.1
         version: 0.0.1
@@ -1316,7 +1322,7 @@ packages:
       '@nuxt/kit': 3.10.0
       '@nuxt/schema': 3.10.0
       execa: 7.2.0
-      nuxt: 3.10.0(@types/node@18.19.14)(vite@5.0.12)
+      nuxt: 3.10.0(@types/node@18.19.14)(typescript@5.3.3)(vite@5.0.12)
       vite: 5.0.12(@types/node@18.19.14)
     transitivePeerDependencies:
       - rollup
@@ -1364,7 +1370,7 @@ packages:
       launch-editor: 2.6.1
       local-pkg: 0.5.0
       magicast: 0.3.3
-      nuxt: 3.10.0(@types/node@18.19.14)(vite@5.0.12)
+      nuxt: 3.10.0(@types/node@18.19.14)(typescript@5.3.3)(vite@5.0.12)
       nypm: 0.3.6
       ohash: 1.1.3
       pacote: 17.0.6
@@ -1467,7 +1473,7 @@ packages:
     resolution: {integrity: sha512-5gc02Pu1HycOVUWJ8aYsWeeXcSTPe8iX8+KIrhyEtEoOSkY0eMBuo0ssljB8wALuEmepv31DlYe5gpiRwkjESA==}
     dev: true
 
-  /@nuxt/vite-builder@3.10.0(@types/node@18.19.14)(vue@3.4.15):
+  /@nuxt/vite-builder@3.10.0(@types/node@18.19.14)(typescript@5.3.3)(vue@3.4.15):
     resolution: {integrity: sha512-PpdcPkvfBzSZVHqxZ/uneTUZq6ufZDzgP36yXxZ/ygRi90szOs5QHWzGFXJ6cCW4D34iqePKjeTXJall3C74LA==}
     engines: {node: ^14.18.0 || >=16.10.0}
     peerDependencies:
@@ -1505,8 +1511,8 @@ packages:
       unplugin: 1.6.0
       vite: 5.0.12(@types/node@18.19.14)
       vite-node: 1.2.2(@types/node@18.19.14)
-      vite-plugin-checker: 0.6.4(vite@5.0.12)
-      vue: 3.4.15
+      vite-plugin-checker: 0.6.4(typescript@5.3.3)(vite@5.0.12)
+      vue: 3.4.15(typescript@5.3.3)
       vue-bundle-renderer: 2.0.0
     transitivePeerDependencies:
       - '@types/node'
@@ -2020,6 +2026,36 @@ packages:
     engines: {node: '>=18'}
     dev: true
 
+  /@size-limit/esbuild@11.0.2(size-limit@11.0.2):
+    resolution: {integrity: sha512-67p+y+wkMBJJegLZUp1X3v1YEvgGSbbAukFbHtxJ1c/DTj/ApiHvtgMzvA5ij+A5UOay+jSU4bXetpNJlUK3Ow==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      size-limit: 11.0.2
+    dependencies:
+      esbuild: 0.19.12
+      nanoid: 5.0.6
+      size-limit: 11.0.2
+    dev: true
+
+  /@size-limit/file@11.0.2(size-limit@11.0.2):
+    resolution: {integrity: sha512-874lrMtWYRL+xb/6xzejjwD+krfHTOo+2uFGpZfJScvuNv91Ni2O7k0o09zC70VzCYBGkXquV92ln/H+/ognGg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    peerDependencies:
+      size-limit: 11.0.2
+    dependencies:
+      size-limit: 11.0.2
+    dev: true
+
+  /@size-limit/preset-small-lib@11.0.2(size-limit@11.0.2):
+    resolution: {integrity: sha512-Yo+RRHCLz29PMmRXzq69E3LjiAivspF2XRGdpZ+QdeFOotd3hBYVMJC9GDF3tEigPtfvEJk4L8YLlUK+SE90FA==}
+    peerDependencies:
+      size-limit: 11.0.2
+    dependencies:
+      '@size-limit/esbuild': 11.0.2(size-limit@11.0.2)
+      '@size-limit/file': 11.0.2(size-limit@11.0.2)
+      size-limit: 11.0.2
+    dev: true
+
   /@trysound/sax@0.2.0:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
@@ -2104,7 +2140,7 @@ packages:
       '@unhead/shared': 1.8.10
       hookable: 5.5.3
       unhead: 1.8.10
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
     dev: true
 
   /@vercel/nft@0.24.4:
@@ -2139,7 +2175,7 @@ packages:
       '@babel/plugin-transform-typescript': 7.23.6(@babel/core@7.23.9)
       '@vue/babel-plugin-jsx': 1.2.1(@babel/core@7.23.9)
       vite: 5.0.12(@types/node@18.19.14)
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2152,7 +2188,7 @@ packages:
       vue: ^3.2.25
     dependencies:
       vite: 5.0.12(@types/node@18.19.14)
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
     dev: true
 
   /@vitest/expect@1.2.2:
@@ -2209,7 +2245,7 @@ packages:
       ast-kit: 0.11.3
       local-pkg: 0.5.0
       magic-string-ast: 0.3.0
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
     transitivePeerDependencies:
       - rollup
     dev: true
@@ -2325,7 +2361,7 @@ packages:
     dependencies:
       '@vue/compiler-ssr': 3.4.15
       '@vue/shared': 3.4.15
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
     dev: true
 
   /@vue/shared@3.4.15:
@@ -2357,7 +2393,7 @@ packages:
       '@vueuse/core': 10.7.2(vue@3.4.15)
       '@vueuse/metadata': 10.7.2
       local-pkg: 0.5.0
-      nuxt: 3.10.0(@types/node@18.19.14)(vite@5.0.12)
+      nuxt: 3.10.0(@types/node@18.19.14)(typescript@5.3.3)(vite@5.0.12)
       vue-demi: 0.14.7(vue@3.4.15)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -2733,6 +2769,11 @@ packages:
     dependencies:
       esbuild: 0.19.12
       load-tsconfig: 0.2.5
+    dev: true
+
+  /bytes-iec@3.1.1:
+    resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
+    engines: {node: '>= 0.8'}
     dev: true
 
   /c12@1.6.1:
@@ -4859,6 +4900,18 @@ packages:
     hasBin: true
     dev: true
 
+  /nanoid@5.0.6:
+    resolution: {integrity: sha512-rRq0eMHoGZxlvaFOUdK1Ev83Bd1IgzzR+WJ3IbDJ7QOSdAxYjlurSPqFs9s4lJg29RT6nPwizFtJhQS6V5xgiA==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    dev: true
+
+  /nanospinner@1.1.0:
+    resolution: {integrity: sha512-yFvNYMig4AthKYfHFl1sLj7B2nkHL4lzdig4osvl9/LdGbXwrdFRoqBS98gsEsOakr0yH+r5NZ/1Y9gdVB8trA==}
+    dependencies:
+      picocolors: 1.0.0
+    dev: true
+
   /napi-wasm@1.1.0:
     resolution: {integrity: sha512-lHwIAJbmLSjF9VDRm9GoVOy9AGp3aIvkjv+Kvz9h16QR3uSVYH78PNQUnT2U4X53mhlnV2M7wrhibQ3GHicDmg==}
     dev: true
@@ -5181,7 +5234,7 @@ packages:
       - supports-color
     dev: true
 
-  /nuxt@3.10.0(@types/node@18.19.14)(vite@5.0.12):
+  /nuxt@3.10.0(@types/node@18.19.14)(typescript@5.3.3)(vite@5.0.12):
     resolution: {integrity: sha512-E9GWyrzTvkoHoJOT847EASEl8KcGDF1twcBgUzDMuNIx+llZ14F+q+XbTjHzYM/o2hqHTer0lLt2RUn5wsBLQQ==}
     engines: {node: ^14.18.0 || >=16.10.0}
     hasBin: true
@@ -5200,7 +5253,7 @@ packages:
       '@nuxt/schema': 3.10.0
       '@nuxt/telemetry': 2.5.3
       '@nuxt/ui-templates': 1.3.1
-      '@nuxt/vite-builder': 3.10.0(@types/node@18.19.14)(vue@3.4.15)
+      '@nuxt/vite-builder': 3.10.0(@types/node@18.19.14)(typescript@5.3.3)(vue@3.4.15)
       '@types/node': 18.19.14
       '@unhead/dom': 1.8.10
       '@unhead/ssr': 1.8.10
@@ -5246,7 +5299,7 @@ packages:
       unplugin: 1.6.0
       unplugin-vue-router: 0.7.0(vue-router@4.2.5)(vue@3.4.15)
       untyped: 1.4.2
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
       vue-bundle-renderer: 2.0.0
       vue-devtools-stub: 0.1.0
       vue-router: 4.2.5(vue@3.4.15)
@@ -6377,6 +6430,19 @@ packages:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
     dev: true
 
+  /size-limit@11.0.2:
+    resolution: {integrity: sha512-iFZ8iTR/3zPqxSwEIdGnTVYVU0F2nhodLQG/G6zpi/NxECYAK9ntq2lNr+prXH7h3gyBjx2Umt2D/oS2Qzz+eg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    dependencies:
+      bytes-iec: 3.1.1
+      chokidar: 3.5.3
+      globby: 14.0.0
+      lilconfig: 3.0.0
+      nanospinner: 1.1.0
+      picocolors: 1.0.0
+    dev: true
+
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -7188,7 +7254,7 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-checker@0.6.4(vite@5.0.12):
+  /vite-plugin-checker@0.6.4(typescript@5.3.3)(vite@5.0.12):
     resolution: {integrity: sha512-2zKHH5oxr+ye43nReRbC2fny1nyARwhxdm0uNYp/ERy4YvU9iZpNOsueoi/luXw5gnpqRSvjcEPxXbS153O2wA==}
     engines: {node: '>=14.16'}
     peerDependencies:
@@ -7230,6 +7296,7 @@ packages:
       semver: 7.5.4
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.1
+      typescript: 5.3.3
       vite: 5.0.12(@types/node@18.19.14)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
@@ -7526,7 +7593,7 @@ packages:
       '@vue/composition-api':
         optional: true
     dependencies:
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
     dev: true
 
   /vue-devtools-stub@0.1.0:
@@ -7539,10 +7606,10 @@ packages:
       vue: ^3.2.0
     dependencies:
       '@vue/devtools-api': 6.5.1
-      vue: 3.4.15
+      vue: 3.4.15(typescript@5.3.3)
     dev: true
 
-  /vue@3.4.15:
+  /vue@3.4.15(typescript@5.3.3):
     resolution: {integrity: sha512-jC0GH4KkWLWJOEQjOpkqU1bQsBwf4R1rsFtw5GQJbjHVKWDzO6P0nWWBTmjp1xSemAioDFj1jdaK1qa3DnMQoQ==}
     peerDependencies:
       typescript: '*'
@@ -7555,6 +7622,7 @@ packages:
       '@vue/runtime-dom': 3.4.15
       '@vue/server-renderer': 3.4.15(vue@3.4.15)
       '@vue/shared': 3.4.15
+      typescript: 5.3.3
     dev: true
 
   /webidl-conversions@3.0.1:


### PR DESCRIPTION
I added `size-limit` util because I think it's important for users to see the library's small size. This could be a deciding factor when using `tempo` instead of `date-fns` or `moment`