### PR TITLE
Fix `tzDate`

### DIFF
--- a/src/__tests__/tzDate.spec.ts
+++ b/src/__tests__/tzDate.spec.ts
@@ -8,4 +8,14 @@ describe("tzDate", () => {
       "2017-05-06T18:00:00.000Z"
     )
   })
+
+  it(`correctly calculates time difference between "${process.env.TZ}" and "Asia/Ho_Chi_Minh"`, () => {
+    const result = tzDate("2024-03-07T02:00", "Asia/Ho_Chi_Minh").toISOString()
+    expect(result).toBe("2024-03-07T14:00:00.000Z")
+  })
+
+  it(`correctly calculates time difference between "${process.env.TZ}" and "Australia/Sydney"`, () => {
+    const result = tzDate("2024-03-07T02:00", "Australia/Sydney").toISOString()
+    expect(result).toBe("2024-03-07T18:00:00.000Z")
+  })
 })

--- a/src/__tests__/tzDate.spec.ts
+++ b/src/__tests__/tzDate.spec.ts
@@ -5,7 +5,7 @@ process.env.TZ = "America/New_York"
 describe("tzDate", () => {
   it("can can parse an unzoned/offset iso8601 as if it was in a timezone", () => {
     expect(tzDate("2017-05-06T12:00", "Europe/Amsterdam").toISOString()).toBe(
-      "2017-05-06T10:00:00.000Z"
+      "2017-05-06T18:00:00.000Z"
     )
   })
 })

--- a/src/tzDate.ts
+++ b/src/tzDate.ts
@@ -15,5 +15,5 @@ import { DateInput } from "./types"
  */
 export function tzDate(inputDate: DateInput, tz: string) {
   const d = date(inputDate)
-  return applyOffset(d, offset(d, tz))
+  return applyOffset(d, offset(d, "UTC", tz))
 }

--- a/src/tzDate.ts
+++ b/src/tzDate.ts
@@ -4,14 +4,22 @@ import { date } from "./date"
 import { DateInput } from "./types"
 
 /**
- * Creates a date object for the input date at the given timezone. For example
- * `tzDate("2017-05-06T12:00", "Europe/Amsterdam")` will return a date object
- * for 2017-05-06T10:00:00Z since 12:00 in Amsterdam is 10:00Z.
+ * Creates a date object for the input date at the given timezone.
+ *
+ * For example with input date is `America/New_York` timezone,
+ * `tzDate("2017-05-06T12:00", "Europe/Amsterdam")` will return
+ * a date object for 2017-05-06T10:00:00Z since 12:00 in `America/New_York`
+ * is 18:00Z in `Europe/Amsterdam` (+6 hours).
  *
  * If given a Date object it will use local time and convert it to the given
  * timezone, thus "changing" the date.
  * @param inputDate - An iso8601 date string with no timezone
  * @param tz - A timezone string
+ * @example
+ * // When the local timezone is 'America/New_York',
+ * process.env.TZ = 'America/New_York'
+ * tzDate("2017-05-06T12:00", "Europe/Amsterdam") //returns a Date object for '2017-05-06T18:00:00Z'.
+ * // This is because 12:00 in 'America/New_York' corresponds to 18:00 in 'Europe/Amsterdam'.
  */
 export function tzDate(inputDate: DateInput, tz: string) {
   const d = date(inputDate)


### PR DESCRIPTION
## Description:

- This pr fix the wrong responds of `tzDate`.
- For example, with the timezone in the test being America/New_York and the timezone to retrieve being Europe/Amsterdam, it means the difference in hours between the two time zones is +6 hours. However, the old `tzDate` returns -2.

## Changed:

- Set tzA of `offset` to default (UTC).
- Jsdoc of `tzDate`

## Added:

- Add passing tests for `tzDate`