### PR TITLE
Fixed the issue where the 'H' disappears when set to 0.

### DIFF
--- a/src/__tests__/format.spec.ts
+++ b/src/__tests__/format.spec.ts
@@ -135,6 +135,11 @@ describe("format", () => {
       format("2100-05-03T04:04:01", { date: "full", time: "short" }, "ja")
     ).toBe("2100年5月3日月曜日 4:04")
   })
+  it("can render a long time in Japanese", () => {
+    expect(
+      format("2010-06-09T15:32:00Z", { time: "full" }, "ja")
+    ).toBe("0時32分00秒 +0900")
+  })
   it("can format the russian month of february", () => {
     expect(format("2023-03-14", { date: "medium" }, "ru")).toBe(
       "14 мар. 2023 г."

--- a/src/common.ts
+++ b/src/common.ts
@@ -175,7 +175,8 @@ export function fill(
     if (partName === "literal") return partValue
     const value = partMap[partName]
     if (partName === "hour" && token === "H") {
-      return value.replace(/^0/, "")
+      const replacedHour = value.replace(/^0/, "")
+      return replacedHour === "" ? "0" : replacedHour
     }
     if (
       (partName === "minute" || partName === "second") &&


### PR DESCRIPTION
Fixed: https://github.com/formkit/tempo/issues/41#issuecomment-2005569614

common.ts#createPartMap#formatToParts(line 242) return `{ 'type': 'hour', 'value': '0' }`
common.ts#fill#value(line 178) return `value.replace(/^0/, "")`
equal '0' -> ''