### PR TITLE
add loose autocomplete in Format type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -81,7 +81,7 @@ export type FormatStyleObj =
   | { date: FormatStyle }
   | { time: FormatStyle }
 
-export type Format = FormatStyle | FormatStyleObj | string
+export type Format = FormatStyle | FormatStyleObj | (string & {})
 
 /**
  * A union of all available formatting tokens.


### PR DESCRIPTION
currently the type for the `format` parameter of the `format` function  doesn't let typescript suggest the possible values. By using `({} & string)` typescript shows the values while also alllowing any string as indended originally

before:
![image](https://github.com/formkit/tempo/assets/48163890/ced46a71-a291-4593-b386-1ad6adbb4d21)

after:
![image](https://github.com/formkit/tempo/assets/48163890/cf9973a0-50e7-417f-b015-27ee683006a5)
