### PR TITLE
docs: add missing homepage/repo in published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,14 @@
       }
     }
   },
+  "homepage": "https://github.com/formkit/tempo",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/formkit/tempo.git"
+  },
+  "bugs": {
+    "url": "https://github.com/formkit/tempo/issues"
+  },
   "scripts": {
     "dev": "cd ./docs && pnpm nuxt dev",
     "build": "tsup",


### PR DESCRIPTION
- while receiving an update from Renovate, I noticed that Tempo does not have the expected hyperlink on the package name and that is because the `homepage` and repo info are missing in the `package.json`

![image](https://github.com/ghiscoding/tempo/assets/643976/16e713a5-1cc0-43b0-86da-d11f4e06754f)
