### PR TITLE
fix(common): handle locales with existing Unicode extension (e.g. ar-u-nu-arab)

### DIFF
--- a/src/__tests__/format.spec.ts
+++ b/src/__tests__/format.spec.ts
@@ -271,4 +271,13 @@ describe("format with a timezone", () => {
       })
     ).toBe("12/19/89, 1:30:10 AM -0600")
   })
+  it("does not throw when locale already contains a Unicode extension subtag (#68)", () => {
+    // ar-u-nu-arab requests Arabic-Indic numerals via BCP 47 Unicode extension.
+    // Previously, format() appended "-u-hc-h23" producing the invalid tag
+    // "ar-u-nu-arab-u-hc-h23" which throws "Invalid language tag".
+    expect(() => format("2024-01-15", "YYYY/MM/DD", "ar-u-nu-arab")).not.toThrow()
+    // The formatted output should use Arabic-Indic digits (٢٠٢٤, etc.)
+    const result = format("2024-01-15", "YYYY/MM/DD", "ar-u-nu-arab")
+    expect(result).toBe("٢٠٢٤/٠١/١٥")
+  })
 })

--- a/src/common.ts
+++ b/src/common.ts
@@ -248,7 +248,14 @@ function createPartMap(
   const genitiveParts: Part[] = []
 
   function addValues(requestedParts: Part[], hour12 = false) {
-    const preciseLocale = `${locale}-u-hc-${hour12 ? "h12" : "h23"}`
+    // Use Intl.Locale to merge the hourCycle extension into the locale tag.
+    // Plain string concatenation (e.g. `${locale}-u-hc-h23`) produces an
+    // invalid BCP 47 tag when the locale already contains a Unicode extension
+    // block (e.g. "ar-u-nu-arab"), because a tag may only have one "-u-" block.
+    // Intl.Locale merges extensions correctly into a single "-u-" subtag.
+    const preciseLocale = new Intl.Locale(locale, {
+      hourCycle: hour12 ? "h12" : "h23",
+    }).toString()
     valueParts.push(
       ...new Intl.DateTimeFormat(
         preciseLocale,


### PR DESCRIPTION
Fixes #68

## Problem

`format()` throws `RangeError: Invalid language tag` when the locale already carries a Unicode extension block, e.g. `ar-u-nu-arab` (Arabic with Arabic-Indic numerals).

The cause is in `createPartMap` (`src/common.ts`): it pins the hour cycle by string-concatenating the extension onto the locale —

```ts
const preciseLocale = `${locale}-u-hc-${hour12 ? "h12" : "h23"}`
```

For `ar-u-nu-arab` this produces `ar-u-nu-arab-u-hc-h23`, which is invalid BCP 47 — a tag may only contain one `-u-` block. `Intl.DateTimeFormat` then throws.

## Fix

Use `Intl.Locale`, which understands the BCP 47 grammar and merges extension subtags into a single, valid `-u-` block (preserving `-nu-arab`):

```ts
const preciseLocale = new Intl.Locale(locale, {
  hourCycle: hour12 ? "h12" : "h23",
}).toString()
```

One-line logic change, plus a regression test.

## Verified

- New test (`does not throw when locale includes a numbering system`) fails before the change with the exact `RangeError`, passes after.
- Full suite: zero regressions — the same pre-existing failures on `main` (machine-local timezone-offset expectations), `+1` net passing.

---

Came across Tempo and noticed #68 had been open a while, so I went ahead and fixed it. No strings attached — I'm with Choreless and we like contributing real fixes to projects we use. If it's useful and you ever want a hand with something larger, happy to help.

— Charles
